### PR TITLE
fix: 청년 편지뷰 헤더 이름 수정

### DIFF
--- a/src/app/letter-detail/[id]/page.tsx
+++ b/src/app/letter-detail/[id]/page.tsx
@@ -117,7 +117,7 @@ const LetterDetailId: React.FC = () => {
   // 청년 버전
   return userData?.roleName === "MENTEE" ? (
     <div className="relative">
-      {/* 오버레이 */}
+      {/* 오버레이  고마움 전달 모달*/}
       {showModal && (
         <>
           <div className="absolute inset-0 z-10 bg-[rgba(51,51,51,0.80)]"></div>
@@ -221,7 +221,7 @@ const LetterDetailId: React.FC = () => {
           />
           <span className="flex-auto text-[#292D32] font-bold text-base leading-6 tracking-tight ml-1">
             {letter.replyLetter
-              ? `${letter?.sendLetter.sendUser}`
+              ? `${letter?.replyLetter.sendUser}`
               : "답장을 기다리는중"}
           </span>
           <Image


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 멘티 편지뷰 헤더에 멘티 이름을 멘토이름으로 수정
## 스크린샷
![image](https://github.com/user-attachments/assets/b44dd3e7-d934-4779-bcaf-dce36397120b)


## 주의사항

Closes #{이슈 번호}
